### PR TITLE
Use bitness instead of x86_64 check for library lookup

### DIFF
--- a/api/vpl/mfxdefs.h
+++ b/api/vpl/mfxdefs.h
@@ -68,7 +68,7 @@ extern "C"
     #define MFX_PACK_BEGIN_STRUCT_W_PTR()    MFX_PACK_BEGIN_X(4)
     #define MFX_PACK_BEGIN_STRUCT_W_L_TYPE() MFX_PACK_BEGIN_X(8)
 /* 32-bit ILP32 data model Linux* */
-#elif defined(__ILP32__)
+#elif defined(__ILP32__) || defined(__arm__)
     #define MFX_PACK_BEGIN_STRUCT_W_PTR()    MFX_PACK_BEGIN_X(4)
     #define MFX_PACK_BEGIN_STRUCT_W_L_TYPE() MFX_PACK_BEGIN_X(4)
 #else

--- a/dispatcher/linux/mfxloader.cpp
+++ b/dispatcher/linux/mfxloader.cpp
@@ -23,15 +23,16 @@
 
 namespace MFX {
 
-#if defined(__x86_64__)
-    #define LIBMFXSW "libmfxsw64.so.1"
+#if INTPTR_MAX == INT32_MAX
+    #define LIBMFXHW "libmfxhw32.so.1"
+    #define ONEVPLSW "libvplswref32.so.1"
+#elif INTPTR_MAX == INT64_MAX
     #define LIBMFXHW "libmfxhw64.so.1"
-
     #define ONEVPLSW "libvplswref64.so.1"
-    #define ONEVPLHW "libmfx-gen.so.1.2"
 #else
     #error Unsupported architecture
 #endif
+#define ONEVPLHW "libmfx-gen.so.1.2"
 
 #undef FUNCTION
 #define FUNCTION(return_value, func_name, formal_param_list, actual_param_list) e##func_name,

--- a/tools/legacy/sample_common/src/sample_utils.cpp
+++ b/tools/legacy/sample_common/src/sample_utils.cpp
@@ -42,11 +42,7 @@
     #include <link.h>
     #include <string>
 
-    #if defined(__x86_64__)
-        #define ONEVPL_MASK "libmfx-gen"
-    #else
-        #error Unsupported architecture
-    #endif
+    #define ONEVPL_MASK "libmfx-gen"
 
 #endif // #if defined(_WIN32) || defined(_WIN64)
 


### PR DESCRIPTION
Both oneVPL SW implementations and dGPUs are available on any platform, so there is no reason to restrict it to x86_64 only.

Remove no longer used LIBMFXSW define.

Also see #1.